### PR TITLE
Add bustools (and latest kallisto)

### DIFF
--- a/bimsb/packages/staging.scm
+++ b/bimsb/packages/staging.scm
@@ -1,7 +1,7 @@
 ;;; GNU Guix --- Functional package management for GNU
 ;;; Copyright © 2015, 2016, 2017, 2018, 2019 Ricardo Wurmus <ricardo.wurmus@mdc-berlin.de>
 ;;; Copyright © 2017 CM Massimo <carlomaria.massimo@mdc-berlin.de>
-;;; Copyright © 2018 Marcel Schilling <marcel.schilling@mdc-berlin.de>
+;;; Copyright © 2018, 2019 Marcel Schilling <marcel.schilling@mdc-berlin.de>
 ;;;
 ;;; This file is NOT part of GNU Guix, but is supposed to be used with GNU
 ;;; Guix and thus has the same license.
@@ -2901,3 +2901,26 @@ interfaces in parallel environments.")
      `(("hwloc" ,hwloc-2.0 "lib")
        ("psm2" ,psm2)
        ,@(alist-delete "psm" (package-inputs openmpi))))))
+
+(define-public bustools
+  (package
+    (name "bustools")
+    (version "0.39.4")
+    (source (origin
+              (method git-fetch)
+              (uri (git-reference
+                    (url "https://github.com/BUStools/bustools")
+                    (commit (string-append "v" version))))
+              (file-name (git-file-name name version))
+              (sha256
+               (base32
+                "111crf85g4gsickylqs99r5pqd5x851sfdylksl29xzypfsqmh3h"))))
+    (build-system cmake-build-system)
+    (arguments `(#:tests? #f))  ; no tests
+    (home-page "https://bustools.github.io")
+    (synopsis "Tools for working with BUS files")
+    (description "bustools is a program for manipulating BUS files for single
+cell RNA-Seq datasets.  It can be used to error correct barcodes, collapse
+UMIs, produce gene count or transcript compatibility count matrices, and is useful
+for many other tasks.")
+    (license license:bsd-2)))

--- a/bimsb/packages/variants.scm
+++ b/bimsb/packages/variants.scm
@@ -1,5 +1,6 @@
 ;;; GNU Guix --- Functional package management for GNU
 ;;; Copyright © 2016, 2017, 2018, 2019 Ricardo Wurmus <ricardo.wurmus@mdc-berlin.de>
+;;; Copyright © 2019 Marcel Schilling <marcel.schilling@mdc-berlin.de>
 ;;;
 ;;; This file is NOT part of GNU Guix, but is supposed to be used with GNU
 ;;; Guix and thus has the same license.
@@ -1121,3 +1122,17 @@ other types of unwanted sequence from high-throughput sequencing reads.")
 
 (define-public dune-grid-agfalke
   (deprecated-package "dune-grid-agfalke" dune-grid-agfalcke))
+
+(define-public kallisto-with-bus
+  (package (inherit kallisto)
+    (name "kallisto")
+    (version "0.46.1")
+    (source (origin
+              (method git-fetch)
+              (uri (git-reference
+                    (url "https://github.com/pachterlab/kallisto.git")
+                    (commit (string-append "v" version))))
+              (file-name (git-file-name name version))
+              (sha256
+               (base32
+                "162jkrm3jpz8hkccjbzx3vgifg8z780awkapyrggp46iidmyydll"))))))


### PR DESCRIPTION
Hi @rekado,

Since Madalin is very busy these days and @zolotarovgl wants to use this on murphy (I think he started mixing in conda to be able to work), I gave this a try. I know I could probably send bustools straight to Guix proper (BSD 2-clause) but I prefer you to have a look at this and run this locally in production before messing with the whole distribution.
Also, I added the latest kallisto (last week) as at least v0.45 is required to generate BUS files to run through bustools. Probably I could have bumped the version for the `kallisto` package instead but again I prefer to not mess with other people's setup so I added a variant `kallisto-with-bus`.

Feel free to undo both of my decisions and submit whatever you feel appropriate to the corresponding channels but for me this works using my fork. So merging this PR should make it work for all BIMSB users incl. everyone on murphy.

Cheers,
Marcel
