### PR TITLE
staging: Adjust hwloc-2 name to match upstream.

### DIFF
--- a/bimsb/packages/staging.scm
+++ b/bimsb/packages/staging.scm
@@ -2869,7 +2869,7 @@ interfaces in parallel environments.")
                 "--with-orte"
                 ,flags))))
     (inputs
-     `(("hwloc" ,hwloc-2.0 "lib")
+     `(("hwloc" ,hwloc-2 "lib")
        ,@(package-inputs openmpi)))))
 
 (define-public openmpi-psm-only
@@ -2883,7 +2883,7 @@ interfaces in parallel environments.")
                 "--with-psm"
                 ,flags))))
     (inputs
-     `(("hwloc" ,hwloc-2.0 "lib")
+     `(("hwloc" ,hwloc-2 "lib")
        ("psm" ,psm)
        ,@(alist-delete "psm2" (package-inputs openmpi))))))
 
@@ -2898,7 +2898,7 @@ interfaces in parallel environments.")
                 "--with-psm2"
                 ,flags))))
     (inputs
-     `(("hwloc" ,hwloc-2.0 "lib")
+     `(("hwloc" ,hwloc-2 "lib")
        ("psm2" ,psm2)
        ,@(alist-delete "psm" (package-inputs openmpi))))))
 


### PR DESCRIPTION
In upstream Guix commit 8c8e108978e0917415c863977b605b84dd01be52,
the following change was done:

>   * gnu/packages/mpi.scm (hwloc-2.0): Rename to...
>   (hwloc-2): ... this.  Update to 2.1.0
>   (hwloc-2.0): Define as deprecated.

This required adjustments to package definitions using hwloc-2.0:

>    * gnu/packages/opencl.scm (pocl)[inputs]: Adjust accordingly.

This commit applies the same changes here to restore compatibility with
upstream.