### PR TITLE
Add MuSiC R package to staging

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,2 @@
+Marcel Schilling <marcel.schilling@uni-luebeck.de>
+Marcel Schilling <marcel.schilling@uni-luebeck.de> <marcel.schilling@mdc-berlin.de>

--- a/bimsb/packages/staging.scm
+++ b/bimsb/packages/staging.scm
@@ -3033,8 +3033,8 @@ provided.")
     (license license:gpl3)))
 
 (define-public r-music
-  (let ((commit "963d32474b937a1954a654caf09b7e92f23a0445")
-        (revision "1"))
+  (let ((commit "7c5834830223957f5d8134c86d6acf653bfff4e7")
+        (revision "2"))
     (package
       (name "r-music")
       (version (string-append "0-" revision "." (string-take commit 9)))
@@ -3045,7 +3045,7 @@ provided.")
                       (commit commit)))
                 (sha256
                  (base32
-                  "0m882yqmj1ihm3s8lny6qj4aww63dmb2ixgad778z5fhphvbnmgy"))))
+                  "098bv7v4phg8iv5h5c27ql4pzc7mcala82mcd4i1y91cf68d0grz"))))
       (build-system r-build-system)
       (propagated-inputs
        `(("r-ggplot2" ,r-ggplot2)

--- a/bimsb/packages/staging.scm
+++ b/bimsb/packages/staging.scm
@@ -1,7 +1,7 @@
 ;;; GNU Guix --- Functional package management for GNU
 ;;; Copyright © 2015, 2016, 2017, 2018, 2019, 2020, 2021 Ricardo Wurmus <ricardo.wurmus@mdc-berlin.de>
 ;;; Copyright © 2017 CM Massimo <carlomaria.massimo@mdc-berlin.de>
-;;; Copyright © 2018, 2019 Marcel Schilling <marcel.schilling@mdc-berlin.de>
+;;; Copyright © 2018, 2019, 2021 Marcel Schilling <marcel.schilling@uni-luebeck.de>
 ;;; Copyright © 2019, 2020 Mădălin Ionel Patrașcu <madalinionel.patrascu@mdc-berlin.de>
 ;;;
 ;;; This file is NOT part of GNU Guix, but is supposed to be used with GNU
@@ -2995,4 +2995,39 @@ the xlxs package.  This release corresponds to POI 3.10.1.")
     (description
      "This package provides R functions to read/write/format Excel
 2007 and Excel 97/2000/XP/2003 file formats.")
+    (license license:gpl3)))
+
+(define-public r-mcmcpack
+  (package
+    (name "r-mcmcpack")
+    (version "1.5-0")
+    (source
+      (origin
+        (method url-fetch)
+        (uri (cran-uri "MCMCpack" version))
+        (sha256
+          (base32
+            "1khavqsimiwbfq7gyw5jyj67jxfd579pnc7mngnd655zc8yzspvr"))))
+    (properties `((upstream-name . "MCMCpack")))
+    (build-system r-build-system)
+    (inputs `(("gcc" ,gcc)))
+    (propagated-inputs
+      `(("r-coda" ,r-coda)
+        ("r-lattice" ,r-lattice)
+        ("r-mass" ,r-mass)
+        ("r-mcmc" ,r-mcmc)
+        ("r-quantreg" ,r-quantreg)))
+    (home-page
+      "https://CRAN.R-project.org/package=MCMCpack")
+    (synopsis
+      "Markov Chain Monte Carlo (MCMC) Package")
+    (description
+      "Contains functions to perform Bayesian inference using posterior
+simulation for a number of statistical models.  Most simulation is done in
+compiled C++ written in the Scythe Statistical Library Version 1.0.3.  All
+models return 'coda' mcmc objects that can then be summarized using the 'coda'
+package.  Some useful utility functions such as density functions,
+pseudo-random number generators for statistical distributions, a general
+purpose Metropolis sampling algorithm, and tools for visualization are
+provided.")
     (license license:gpl3)))

--- a/bimsb/packages/staging.scm
+++ b/bimsb/packages/staging.scm
@@ -3031,3 +3031,31 @@ pseudo-random number generators for statistical distributions, a general
 purpose Metropolis sampling algorithm, and tools for visualization are
 provided.")
     (license license:gpl3)))
+
+(define-public r-music
+  (let ((commit "963d32474b937a1954a654caf09b7e92f23a0445")
+        (revision "1"))
+    (package
+      (name "r-music")
+      (version (string-append "0-" revision "." (string-take commit 9)))
+      (source (origin
+                (method git-fetch)
+                (uri (git-reference
+                      (url "https://github.com/xuranw/MuSiC.git")
+                      (commit commit)))
+                (sha256
+                 (base32
+                  "0m882yqmj1ihm3s8lny6qj4aww63dmb2ixgad778z5fhphvbnmgy"))))
+      (build-system r-build-system)
+      (propagated-inputs
+       `(("r-ggplot2" ,r-ggplot2)
+         ("r-plyr" ,r-plyr)
+         ("r-mcmcpack" ,r-mcmcpack)
+         ("r-nnls" ,r-nnls)
+         ("r-xbioc" ,r-xbioc)))
+      (home-page "https://github.com/xuranw/MuSiC")
+      (synopsis "Multi-subject Single Cell deconvolution")
+      (description
+       "MuSiC is a deconvolution method that utilizes cross-subject scRNA-seq
+to estimate cell type proportions in bulk RNA-seq data.")
+      (license license:gpl3))))


### PR DESCRIPTION
This PR add the [MuSiC R package](https://github.com/xuranw/MuSiC) (and its dependency [MCMCpack](https://cran.r-project.org/package=MCMCpack)) to the staging area.
I have build it locally and sucessfully run (the first part of) [the MuSiC tutorial](http://xuranw.github.io/MuSiC/articles/MuSiC.html) under `guix environment --ad-hoc r r-music`.

Since MCMpack is on CRAN, I used `guix import cran MCMCpack` to generate the package definition (which, btw., created an invalid license specification: `gpl3` instead of `license:gpl3`).
MuSiC on the other hand has no versioned release and suggest `devtools::install_github('xuranw/MuSiC')` for the installation.
Thus, I had to hack something together based on other R packages pulling the source directly from Github.
Therefore, I'd appreciate some extra pair(s) of eyes and critical feedback before this goes out to Guix proper.

Finally, this also includes a `.mailcap` file [as suggested elsewhere](https://github.com/BIMSBbioinfo/guix-bimsb-nonfree/pull/6#discussion_r599349487)  by @rekado.